### PR TITLE
feat: add feature to auto parse versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,17 @@ For now, I'm only comfortable saying Bethesda games are "officially" supported, 
 Use the plugin settings in MO2 to configure things like the list name, version, private, etc.
 The defaults are as follows:
 
-| Setting          | Default                 |
-| ---------------- | ----------------------- |
-| list_name        | My List                 |
-| list_version     | 0.0.1                   |
-| list_description |                         |
-| list_website     |                         |
-| list_discord     |                         |
-| list_readme      |                         |
-| list_private     | False                   |
-| upload_files     | modlist.txt,plugins.txt |
+| Setting              | Default                 | Note                                            |
+| -------------------- | ----------------------- | ----------------------------------------------- |
+| list_name            | My List                 | The name of your list.                          |
+| list_version         | 0.0.1                   | The verison.                                    |
+| list_description     |                         | A short description of the list, optional.      |
+| list_website         |                         | The website for the list, if it has one.        |
+| list_discord         |                         | Discord for list support.                       |
+| list_readme          |                         | The list's readme file.                         |
+| list_private         | False                   | If the list is private or not.                  |
+| upload_files         | modlist.txt,plugins.txt | What files will be uploaded.                    |
+| version_auto_parsing | False                   | Attempt to auto parse version from a separator. |
 
 For files to upload, add them separated by a comma like the default. A list requires at least one file to be uploaded.
 
@@ -73,3 +74,7 @@ If you are using an API Token, future uploads will _update_ the list you just cr
 # Installation
 
 Extract the folder in the archive to `%MO2DIR%/plugins` such that it becomes `%MO2DIR%/plugins/lolmo2plugin`
+
+# Known Issues/Limitation
+
+Currently, if one wants to upload a list without a version and they remove the defualt, lists will be uploaded with a version of `None`.

--- a/modules/load_order_library.py
+++ b/modules/load_order_library.py
@@ -11,7 +11,7 @@ except:
     from PyQt6.QtWidgets import QMessageBox
 
 VERSION = "1.3.0"
-BASE_URI = "https://api.loadorderlibrary.com/v1"
+BASE_URI = "https://testingapi.loadorderlibrary.com/v1"
 LISTS_URI = BASE_URI + "/lists"
 
 
@@ -190,6 +190,14 @@ class LolUpload:
                         )
                         if ver:
                             return ver.group(1)
+                        else:
+                            # LookupError prob not the most accurate
+                            # but it's better than a generic exception
+                            # and I don't feel like making my own error.
+                            raise LookupError(
+                                "No version could be found in a separator."
+                            )
+
             except Exception as e:
                 msg = QMessageBox()
                 msg.setIcon(QMessageBox.Icon.Critical)

--- a/modules/load_order_library.py
+++ b/modules/load_order_library.py
@@ -11,7 +11,7 @@ except:
     from PyQt6.QtWidgets import QMessageBox
 
 VERSION = "1.3.0"
-BASE_URI = "https://testingapi.loadorderlibrary.com/v1"
+BASE_URI = "https://loadorderlibrary.com/v1"
 LISTS_URI = BASE_URI + "/lists"
 
 

--- a/modules/load_order_library.py
+++ b/modules/load_order_library.py
@@ -3,13 +3,14 @@ import os
 import json
 import urllib.parse
 import urllib.request as request
+import re
 
 try:
     from PyQt5.QtWidgets import QMessageBox
 except:
     from PyQt6.QtWidgets import QMessageBox
 
-VERSION = "1.2.1"
+VERSION = "1.3.0"
 BASE_URI = "https://api.loadorderlibrary.com/v1"
 LISTS_URI = BASE_URI + "/lists"
 
@@ -48,7 +49,7 @@ class LolUpload:
         "Zeus and Poseidon": 27,
     }
 
-    def __init__(self, plugin, apiToken=None, slug=None):
+    def __init__(self, plugin):
         self._plugin = plugin
 
     def upload(self):
@@ -61,11 +62,12 @@ class LolUpload:
 
     def updateList(self, plugin):
         url = f"{LISTS_URI}/{self._plugin._slug}"
+        version = self._getVersion(plugin)
 
         data = {
             "name": plugin.getSetting("list_name"),
             "game": str(self._gameIds[plugin._organizer.managedGame().gameName()]),
-            "version": plugin.getSetting("list_version"),
+            "version": version,
             "description": plugin.getSetting("list_description"),
             "website": plugin.getSetting("list_website"),
             "discord": plugin.getSetting("list_discord"),
@@ -88,11 +90,12 @@ class LolUpload:
 
     def createList(self, plugin):
         url = LISTS_URI
+        version = self._getVersion(plugin)
 
         data = {
             "name": plugin.getSetting("list_name"),
             "game": str(self._gameIds[plugin._organizer.managedGame().gameName()]),
-            "version": plugin.getSetting("list_version"),
+            "version": version,
             "description": plugin.getSetting("list_description"),
             "website": plugin.getSetting("list_website"),
             "discord": plugin.getSetting("list_discord"),
@@ -169,3 +172,30 @@ class LolUpload:
                 error_response_data = e.read()
                 # Process the error response data as needed
                 return json.loads(error_response_data.decode("utf-8"))
+
+    def _getVersion(self, plugin):
+        autoParse = plugin.getSetting("version_auto_parsing")
+
+        if autoParse:
+            try:
+                with open(
+                    f"{plugin._organizer.profile().absolutePath()}/modlist.txt"
+                ) as f:
+                    lines = f.readlines()
+                    for line in lines:
+                        # Doesn't 100% adhere to semver, but I don't force semver on
+                        # Load Order Library anyway, so that's fine.
+                        ver = re.search(
+                            "^^-.*v(\d+\.\d+\.\d+[^\s]*).*_separator$", line
+                        )
+                        if ver:
+                            return ver.group(1)
+            except Exception as e:
+                msg = QMessageBox()
+                msg.setIcon(QMessageBox.Icon.Critical)
+                msg.setWindowTitle("File Read Error!")
+                msg.setText(f"Something went wrong looking for a version. {e}")
+                msg.exec()
+                raise
+        else:
+            return re.sub("^v?", "", plugin.getSetting("list_version"))

--- a/plugins/upload.py
+++ b/plugins/upload.py
@@ -28,7 +28,7 @@ class LolMo2Upload(mobase.IPluginTool):
     _organizer: mobase.IOrganizer
     _profile: mobase.IProfile
     _name = "Load Order Library Upload"
-    _frontendUrl = "https://testing.loadorderlibrary.com"
+    _frontendUrl = "https://loadorderlibrary.com"
     _appDataDir = "LoadOrderLibrary"
     _dataFile = ""
     _apiToken = None

--- a/plugins/upload.py
+++ b/plugins/upload.py
@@ -28,7 +28,7 @@ class LolMo2Upload(mobase.IPluginTool):
     _organizer: mobase.IOrganizer
     _profile: mobase.IProfile
     _name = "Load Order Library Upload"
-    _frontendUrl = "https://loadorderlibrary.com"
+    _frontendUrl = "https://testing.loadorderlibrary.com"
     _appDataDir = "LoadOrderLibrary"
     _dataFile = ""
     _apiToken = None

--- a/plugins/upload.py
+++ b/plugins/upload.py
@@ -60,7 +60,7 @@ class LolMo2Upload(mobase.IPluginTool):
         return self.tr("Allows uploading directly to Load Order Library.")
 
     def version(self) -> mobase.VersionInfo:
-        return mobase.VersionInfo(1, 2, 1, mobase.ReleaseType.FINAL)
+        return mobase.VersionInfo(1, 3, 0, mobase.ReleaseType.FINAL)
 
     def isActive(self) -> bool:
         return self._organizer.pluginSetting(self.name(), "enabled")
@@ -79,6 +79,11 @@ class LolMo2Upload(mobase.IPluginTool):
                 "upload_files",
                 "A list of the files to upload",
                 "modlist.txt,plugins.txt",
+            ),
+            self.setSetting(
+                "version_auto_parsing",
+                "Attempt to auto parse the version from a separator. Looks for semver format.",
+                False,
             ),
         ]
 
@@ -134,7 +139,7 @@ class LolMo2Upload(mobase.IPluginTool):
 
     def popup_button(self, i) -> None:
         if i.text() == "OK":
-            lolUpload = LolUpload(self, self._apiToken, self._slug)
+            lolUpload = LolUpload(self)  # Pass in the plugin
             list = lolUpload.upload()
             if "data" in list.keys():
                 url = self._frontendUrl + list["data"]["links"]["url"]


### PR DESCRIPTION
Adds a setting `version_auto_parsing` (default false) to attempt to auto parse a version from a separator. 

Fails upload if no version is found.

closes: #4 